### PR TITLE
Use SHA256 checksum instead of SHA1

### DIFF
--- a/etherape.rb
+++ b/etherape.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Etherape < Formula
   homepage 'http://etherape.sourceforge.net/'
   url 'http://downloads.sourceforge.net/project/etherape/etherape/0.9.13/etherape-0.9.13.tar.gz'
-  sha1 '87c387b0929071581bcb6515b15ab849ea8c77fb'
+  sha256 '2a3d2a28b824ce4797529bb90d19a213d80e70f5b3f0cc5f455379aac31c09f7'
 
 
   depends_on 'pkg-config' => :build

--- a/gnome-mime-data.rb
+++ b/gnome-mime-data.rb
@@ -3,7 +3,7 @@ require 'formula'
 class GnomeMimeData < Formula
   homepage ''
   url 'http://ftp.gnome.org/pub/gnome/sources/gnome-mime-data/2.18/gnome-mime-data-2.18.0.tar.gz'
-  sha1 '84ff364d6cba72d638b0afea600e0151c42c88e8'
+  sha256 '86638a38d5e1d05687ee36ddfecab106dc127b120194a55aca0d3ed289a21037'
 
   depends_on :x11
   depends_on 'pkg-config' => :build

--- a/gnome-vfs.rb
+++ b/gnome-vfs.rb
@@ -3,7 +3,7 @@ require 'formula'
 class GnomeVfs < Formula
   homepage ''
   url 'http://ftp.gnome.org/pub/gnome/sources/gnome-vfs/2.24/gnome-vfs-2.24.4.tar.gz'
-  sha1 '3481234bc76b9a5f13b62635499999f1f501e1aa'
+  sha256 '2eb84be8d260e3c4f13b68e820acf4100e97956f6953067a99119fa8d88c5c00'
 
   def patches
     #From https://trac.macports.org/browser/trunk/dports/gnome/gnome-vfs/files/enable-deprecated.diff

--- a/libbonobo.rb
+++ b/libbonobo.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Libbonobo < Formula
   homepage ''
   url 'http://ftp.gnome.org/pub/GNOME/sources/libbonobo/2.32/libbonobo-2.32.1.tar.gz'
-  sha1 'adc153233271d355f214846d981f91a923a45c0e'
+  sha256 '59f95f55fdb6bc56f4fcd081ce5c61affbc67cdad6b61e0ca2aaf34d7efe95b9'
 
   depends_on 'pkg-config' => :build
   depends_on 'gettext'

--- a/libbonoboui.rb
+++ b/libbonoboui.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Libbonoboui < Formula
   homepage ''
   url 'http://ftp.gnome.org/pub/GNOME/sources/libbonoboui/2.24/libbonoboui-2.24.5.tar.gz'
-  sha1 '3b66aa7c185cd445856ab8cf2b527bcd4952cf06'
+  sha256 '2792973184106abe805109ac9b5f750f4015347af077e22cf50001f3f51aa829'
 
   depends_on :x11
   depends_on 'pkg-config' => :build

--- a/libcanberra.rb
+++ b/libcanberra.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Libcanberra < Formula
   homepage ''
   url 'http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz'
-  sha1 'fd4c16e341ffc456d688ed3462930d17ca6f6c20'
+  sha256 'c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72'
 
   def patches
     #

--- a/libgnome.rb
+++ b/libgnome.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Libgnome < Formula
   homepage ''
   url 'http://ftp.gnome.org/pub/GNOME/sources/libgnome/2.32/libgnome-2.32.1.tar.gz'
-  sha1 '70c058b839dfbce93d826340ab9100154751fb17'
+  sha256 'b9ef58e22708e5ada10757fdb384161b750555d65936103e3191511967d79c17'
 
   def patches
     #From https://trac.macports.org/browser/trunk/dports/gnome/gnome-vfs/files/enable-deprecated.diff

--- a/libgnomeui.rb
+++ b/libgnomeui.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Libgnomeui < Formula
   homepage ''
   url 'http://ftp.gnome.org/pub/gnome/sources/libgnomeui/2.24/libgnomeui-2.24.5.tar.gz'
-  sha1 '404bd8b7a252362c322d5bda3d1ffe731b7e4645'
+  sha256 '0a7ae41bf6161eabd52a4a845d1941b29d595a422bd3b7275ab1db0c7a3de9cb'
 
   depends_on 'pkg-config' => :build
   depends_on :x11 # if your formula requires any X11/XQuartz component


### PR DESCRIPTION
This addresses such warning messages:

```
Warning: Calling Resource#sha1 is deprecated!
Use Resource#sha256 instead.
```

And should resolve #2 

GNOME source checksums provided by `sha256sum` files on their FTP server.
Other source checksums calculated locally on a file matching the original SHA1 checksum.
